### PR TITLE
output url is now scheme independent, added embed url support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -213,3 +213,5 @@ pip-log.txt
 
 #Mr Developer
 .mr.developer.cfg
+
+sftp-config.json

--- a/library.js
+++ b/library.js
@@ -2,11 +2,19 @@
 	"use strict";
 
 	var Youtube = {},
-		embed = '<iframe class="youtube-plugin" width="640" height="360" src="http://www.youtube.com/embed/$1" frameborder="0" allowfullscreen></iframe>';
+		embed = '<iframe class="youtube-plugin" width="640" height="360" src="//www.youtube.com/embed/$1" frameborder="0" allowfullscreen></iframe>';
 
 	Youtube.parse = function(postContent, callback) {
 		// modified from http://stackoverflow.com/questions/7168987/
-		postContent = postContent.replace(/<a href="(?:https?:\/\/)?(?:www\.)?(?:youtube\.com|youtu\.be)\/(?:watch\?v=)?(.+)<\/a>/g, embed);
+		var	regularUrl = /<a href="(?:https?:\/\/)?(?:www\.)?(?:youtube\.com|youtu\.be)\/(?:watch\?v=)?(.+)">.+<\/a>/g,
+			embedUrl = /<a href="(?:https?:\/\/)?(?:www\.)youtube.com\/embed\/([\w\-_]+)">.+<\/a>/;
+
+		if (postContent.match(embedUrl)) {
+			postContent = postContent.replace(embedUrl, embed);
+		} else if (postContent.match(regularUrl)) {
+			postContent = postContent.replace(regularUrl, embed);
+		}
+
 		callback(null, postContent);
 	};
 

--- a/plugin.json
+++ b/plugin.json
@@ -5,7 +5,7 @@
 	"url": "https://github.com/psychobunny/nodebb-plugin-youtube",
 	"library": "./library.js",
 	"hooks": [
-		{ "hook": "filter:post.parse", "method": "parse", "callbacked": true }
+		{ "hook": "filter:post.parse", "method": "parse", "callbacked": true, "priority": 6 }
 	],
 	"staticDir": "./static",
 	"css": [


### PR DESCRIPTION
- Output url is now scheme independent (so HTTPS NodeBBs won't balk at the plugin outputting `http` only)
- Embed URLs now supported (e.g. http://www.youtube.com/embed/qEb4TG10jW8)
- Plugin is now priority 6 (will always be run after parsers, who have priority 5)
