### PR TITLE
Fix plugin converting user links to videos

### DIFF
--- a/library.js
+++ b/library.js
@@ -6,13 +6,18 @@
 
 	Youtube.parse = function(postContent, callback) {
 		// modified from http://stackoverflow.com/questions/7168987/
-		var	regularUrl = /<a href="(?:https?:\/\/)?(?:www\.)?(?:youtube\.com|youtu\.be)\/(?:watch\?v=)?(.+)">.+<\/a>/g,
-			embedUrl = /<a href="(?:https?:\/\/)?(?:www\.)youtube.com\/embed\/([\w\-_]+)">.+<\/a>/;
+		var	regularUrl = /<a href="(?:https?:\/\/)?(?:www\.)?(?:youtube\.com)\/(?:watch\?v=)(.+)">.+<\/a>/g;
+		var	shortUrl = /<a href="(?:https?:\/\/)?(?:www\.)?(?:youtu\.be)\/(.+)">.+<\/a>/g;
+		var	embedUrl = /<a href="(?:https?:\/\/)?(?:www\.)youtube.com\/embed\/([\w\-_]+)">.+<\/a>/;
 
 		if (postContent.match(embedUrl)) {
 			postContent = postContent.replace(embedUrl, embed);
-		} else if (postContent.match(regularUrl)) {
+		}
+		if (postContent.match(regularUrl)) {
 			postContent = postContent.replace(regularUrl, embed);
+		}
+		if (postContent.match(shortUrl)) {
+			postContent = postContent.replace(shortUrl, embed);
 		}
 
 		callback(null, postContent);


### PR DESCRIPTION
An issue in the regex intentionally placed for the simultaneous parsing of youtu
be.com/watch?v= and youtu.be/ links caused links in the format youtube.com/user/
somebody and youtube.com/somebody to wrongly show up as videos. This made going
to the links impossible. This commit separates the shortUrl into its own regex t
o be matched separately, so the regular URL does not have false positives.
