### PR TITLE
added code to make embedded videos more responsive

### DIFF
--- a/library.js
+++ b/library.js
@@ -1,8 +1,8 @@
 (function(module) {
 	"use strict";
-
+	// responsive format found at http://avexdesigns.com/responsive-youtube-embed/
 	var Youtube = {},
-		embed = '<iframe class="youtube-plugin" width="640" height="360" src="//www.youtube.com/embed/$1?wmode=opaque" frameborder="0" allowfullscreen></iframe>';
+		embed = '<div class="video-container"><iframe class="youtube-plugin" width="640" height="360" src="//www.youtube.com/embed/$1?wmode=opaque" allowfullscreen></iframe></div>';
 
 	Youtube.parse = function(postContent, callback) {
 		// modified from http://stackoverflow.com/questions/7168987/

--- a/static/style.css
+++ b/static/style.css
@@ -1,3 +1,19 @@
 iframe.youtube-plugin {
 	border: 0;
 }
+.video-container {
+    position: relative;
+    padding-bottom: 56.25%;
+    padding-top: 30px; height: 0; overflow: hidden;
+}
+ 
+.video-container iframe,
+.video-container object,
+.video-container embed {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+}
+


### PR DESCRIPTION
Videos in the small format spilled over into the left margin, which enabled horizontal scrolling and inability to see the whole video screenshot. This fix, well, fixes that.
